### PR TITLE
Slide fixes

### DIFF
--- a/GrowingRectangleChallenge/Solution2.html
+++ b/GrowingRectangleChallenge/Solution2.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>My First ProcessingJS project</title>
+</head>
+<body>
+
+	<canvas id="myProcessingProject"></canvas>
+	<script src="processing.min.js"></script>
+
+	<script>
+		var width = 10;
+		var height = 20;
+		var greenValue = 0;
+		function sketchProc(processing) {
+			processing.setup = function() {
+				//the code for your basic setup functions goes here
+				processing.size(700,500);
+				processing.background(15,200,80);
+		   };
+		   processing.draw = function() {
+				processing.background(15,greenValue,80);
+
+				if (processing.mouseX > 10 && processing.mouseX < (width + 10) && processing.mouseY > 20 && processing.mouseY < (height + 20)) {
+				  processing.fill(255,0,0);
+				} else {
+				  processing.fill(0,0,255);
+				}
+				
+				processing.rect(10,20,width,height);
+				processing.fill(0,255,0);
+				 processing.ellipse(processing.mouseX, processing.mouseY, 25, 25);
+
+				if (height >= 480) {
+  					console.log('all done');
+				} else {
+					width = width + 0.5;
+					height = height + 0.8;
+					greenValue = greenValue + 0.8;
+				}
+
+		   };
+
+		};
+ 		
+ 		var canvas = document.getElementById("myProcessingProject");
+		var processingInstance = new Processing(canvas, sketchProc);
+	</script>
+
+</body>
+</html>

--- a/slides.html
+++ b/slides.html
@@ -497,7 +497,7 @@ var fails = 'This string's value is not going to work!';
         Or *escape* it by using a backslash.
 
         ```javascript
-        var alsoWorks = 'This string\'s value is not going to work!';
+        var alsoWorks = 'This string\'s value will also work!';
         ```
 
         > Try adding each line into your console to check for errors.
@@ -933,11 +933,15 @@ var fails = 'This string's value is not going to work!';
 
         The first step is telling your web page how to read Processing commands. That means importing the library. Throw this code at the end of your BODY tag.
 
-        ```
-        < canvas id="myProcessingProject"></ canvas>
 
-        < script src="processing.min.js">< /script>
-        ```
+<pre><code class="hljs xml"><span class="hljs-tag">&lt;<span class="hljs-title">canvas</span> <span class="hljs-attribute">id</span>=<span class="hljs-value">"myProcessingProject"</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">canvas</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-title">script</span> <span class="hljs-attribute">src</span>=<span class="hljs-value">"processing.min.js"</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">script</span>&gt;</span></code></pre>
+
+
+<!-- This is the output from running this code through it:
+        <canvas id="myProcessingProject"></canvas>
+        <script src="processing.min.js"></script>
+-->
 
         We add the CANVAS element to hold all of our Processing output. Instead of drawing HTML elements, we're going to be drawing to the canvas. 
 
@@ -993,7 +997,7 @@ var fails = 'This string's value is not going to work!';
     <section class="slide">
       <h1>The Draw function</h1>
 
-      <p>Just as we explored earlier, draw() is a method in Processing that actually adds elements to your canvas. It draws on your canvas.</p>
+      <p>draw() is a method in Processing that actually adds elements to your canvas. It draws on your canvas.</p>
 
       <p>The draw() method is not static, though. It keeps repeating over and over and over again. It's a constantly running loop. draw() is triggered 60 times per second, or once every 160 milliseconds.</p>
 
@@ -1158,7 +1162,7 @@ var fails = 'This string's value is not going to work!';
       <script type="text/template">
         #Challenge: The case of the growing rect() (code-along)
 
-        JavaScript let's you establish global variables that can start off as one value, but adjust as the program runs. So at the top of your sketchProc function, add these two variables:
+        JavaScript lets you establish global variables that can start off as one value, but adjust as the program runs. So at the top of your sketchProc function, add these two variables:
 
         ```
         var wide = 10;

--- a/starter.html
+++ b/starter.html
@@ -5,47 +5,9 @@
 </head>
 <body>
 
-	<canvas id="myProcessingProject"></canvas>
-	<script src="processing.min.js"></script>
+  <script>
 
-	<script>
-		var width = 10;
-		var height = 20;
-		var greenValue = 0;
-		function sketchProc(processing) {
-			processing.setup = function() {
-				//the code for your basic setup functions goes here
-				processing.size(700,500);
-				processing.background(15,200,80);
-		   };
-		   processing.draw = function() {
-				processing.background(15,greenValue,80);
-
-				if (processing.mouseX > 10 && processing.mouseX < (width + 10) && processing.mouseY > 20 && processing.mouseY < (height + 20)) {
-				  processing.fill(255,0,0);
-				} else {
-				  processing.fill(0,0,255);
-				}
-				
-				processing.rect(10,20,width,height);
-				processing.fill(0,255,0);
-				 processing.ellipse(processing.mouseX, processing.mouseY, 25, 25);
-
-				if (height >= 480) {
-  					console.log('all done');
-				} else {
-					width = width + 0.5;
-					height = height + 0.8;
-					greenValue = greenValue + 0.8;
-				}
-
-		   };
-
-		};
- 		
- 		var canvas = document.getElementById("myProcessingProject");
-		var processingInstance = new Processing(canvas, sketchProc);
-	</script>
+  </script>
 
 </body>
 </html>


### PR DESCRIPTION
Various fixes that I made after teaching this course twice.

    1. Fix an error on slide 32 where it claims that a string
    which is syntactically correct is actually incorrect.
    
    2. Use some HTML trickery to remove some incorrect spaces that were
    appearing in slides and confusing students. The spaces were there
    because the writer was trying to "escape" some elements. Instead
    I replaced them with the output of the markdown interpreter.
    
    3. Slide 60 implied we had already talked about draw() when we had
    not.
    
    4. There was a small grammar mistake: let's versus lets on slide 

 5.    "starter.html" was not a real starter file. Now it is.
